### PR TITLE
Added if check and return error for filters with empty groups

### DIFF
--- a/posthog/api/feature_flag.py
+++ b/posthog/api/feature_flag.py
@@ -394,6 +394,12 @@ class FeatureFlagSerializer(
             # mypy cannot tell that self.instance is a FeatureFlag
             return self.instance.filters
 
+        groups = filters.get("groups", [])
+        if isinstance(groups, list) and len(groups) == 0:
+            raise serializers.ValidationError(
+            "Feature flag filters must contain at least one condition set. Empty 'groups' array is not allowed."
+            )
+
         aggregation_group_type_index = filters.get("aggregation_group_type_index", None)
 
         def properties_all_match(predicate):


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #38896

## Changes
Added if check for empty groups and gave an proper error for for creating a feature flag with empty groups
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saving feature flag filters with an empty "groups" list; attempts now return a clear validation error.
  * PATCH updates that omit "groups" continue to behave as before, ensuring backward compatibility.
  * Improves reliability by catching invalid configurations earlier and reducing unexpected behavior during flag evaluation.
  * No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->